### PR TITLE
OpenSSH Client: Fix for "Bad SSH2 Mac spec"

### DIFF
--- a/index.html
+++ b/index.html
@@ -372,7 +372,7 @@ MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-
         <pre class="pre-trans" id="sshconfig">
 HashKnownHosts yes
 Host github.com
-    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-128-etm@openssh.com,hmac-sha2-512
+    MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512
 Host *
   ConnectTimeout 30
   KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256


### PR DESCRIPTION
OpenSSH Client on macOS Sierra throws the following error with the ciphers used for GitHub:

```
Bad SSH2 Mac spec 'hmac-sha2-512-etm@openssh.com,hmac-sha2-128-etm@openssh.com,hmac-sha2-512'.
```

Version: `OpenSSH_7.5p1, OpenSSL 1.0.2l  25 May 2017`
